### PR TITLE
Potential fix for code scanning alert no. 2: Bad HTML filtering regexp

### DIFF
--- a/src/utils/blogAdmin.js
+++ b/src/utils/blogAdmin.js
@@ -65,10 +65,7 @@ export const getBlogCategories = (blog = {}) => {
 };
 
 export const stripHtml = (value = "") =>
-    String(value || "")
-        .replace(/<style[\s\S]*?<\/style>/gi, " ")
-        .replace(/<script[\s\S]*?<\/script>/gi, " ")
-        .replace(/<[^>]+>/g, " ")
+    DOMPurify.sanitize(String(value || ""), { ALLOWED_TAGS: [], ALLOWED_ATTR: [] })
         .replace(/&nbsp;/g, " ")
         .replace(/&amp;/g, "&")
         .replace(/&lt;/g, "<")


### PR DESCRIPTION
Potential fix for [https://github.com/tamfuldev/tamfuldev.github.io/security/code-scanning/2](https://github.com/tamfuldev/tamfuldev.github.io/security/code-scanning/2)

General fix: stop relying on ad-hoc HTML regexes for security-sensitive stripping, and use a well-tested sanitizer/parser path first.

Best targeted fix in `src/utils/blogAdmin.js`: update `stripHtml` to sanitize input with `DOMPurify.sanitize(..., { ALLOWED_TAGS: [] })` so all HTML tags (including malformed/script edge cases) are removed safely, then keep the existing entity/whitespace normalization behavior. This preserves existing functionality (returning normalized plain text) while eliminating the vulnerable `<script...<\/script>` regex logic.

What to change:
- In `stripHtml` (lines 67–79 region), replace the regex-based `<style>`, `<script>`, and generic tag stripping with a `DOMPurify.sanitize` call configured to allow no tags.
- Keep the subsequent `.replace(/&nbsp;/g, " ")`, entity conversions, whitespace collapse, and `.trim()`.

No new imports are needed since `DOMPurify` is already imported on line 1.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
