### PR TITLE
Potential fix for code scanning alert no. 2: Bad HTML filtering regexp

### DIFF
--- a/src/utils/blogAdmin.js
+++ b/src/utils/blogAdmin.js
@@ -65,9 +65,7 @@ export const getBlogCategories = (blog = {}) => {
 };
 
 export const stripHtml = (value = "") =>
-    String(value || "")
-        .replace(/<style[\s\S]*?<\/style>/gi, " ")
-        .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    DOMPurify.sanitize(String(value || ""), { USE_PROFILES: { html: true } })
         .replace(/<[^>]+>/g, " ")
         .replace(/&nbsp;/g, " ")
         .replace(/&lt;/g, "<")


### PR DESCRIPTION
Potential fix for [https://github.com/tamfuldev/tamfuldev.github.io/security/code-scanning/2](https://github.com/tamfuldev/tamfuldev.github.io/security/code-scanning/2)

Best fix: stop relying on fragile regex for script/style removal and sanitize via a well-tested HTML sanitizer (`DOMPurify`) before stripping tags to text.

In `src/utils/blogAdmin.js`, update `stripHtml` (lines 67–79 region) to:
1. Convert input to string.
2. Sanitize using `DOMPurify.sanitize(...)` with a strict profile (HTML only).
3. Then strip remaining tags and decode entities as currently done.

This preserves current functionality (returns plain text, normalizes whitespace, decodes common entities) while removing the vulnerable custom script regex behavior that CodeQL flagged. No new imports are needed because `DOMPurify` is already imported at line 1.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
